### PR TITLE
Add controller utilities and application object

### DIFF
--- a/lib/stacks.d.ts
+++ b/lib/stacks.d.ts
@@ -263,7 +263,7 @@ declare global {
         ): void;
         
         /**
-         * Create a Stimulus controller from an old-fashioned (pre-ES6) Javascript object. All own enumerable 
+         * Create a Stimulus controller from an old-fashioned (pre-ES6) JavaScript object. All own enumerable 
          * properties of that object will be made available on the controller prototype, with the exception of
          * the targets property, which will be available on the controller constructor itself, i.e. statically.
          * @param controllerDefinition plain JavaScript object that is analogous to the ES6 class

--- a/lib/stacks.d.ts
+++ b/lib/stacks.d.ts
@@ -272,7 +272,7 @@ declare global {
             controllerDefinition: ControllerDefinition
         ): typeof StacksController;
         /**
-         * Register a Stimulus controller from an old-fashioned (pre-ES6) Javascript object.
+         * Register a Stimulus controller from an old-fashioned (pre-ES6) JavaScript object.
          * @param name identifier for this controller
          * @param controller plain JavaScript object that is analogous to the ES6 class
          */

--- a/lib/stacks.d.ts
+++ b/lib/stacks.d.ts
@@ -274,12 +274,9 @@ declare global {
         /**
          * Register a Stimulus controller from an old-fashioned (pre-ES6) Javascript object.
          * @param name identifier for this controller
-         * @param controllerDefinition plain JavaScript object that is analogous to the ES6 class
+         * @param controller plain JavaScript object that is analogous to the ES6 class
          */
-        function addController(
-            name: string,
-            controller: ControllerDefinition
-        ): void;
+        function addController(name: string, controller: ControllerDefinition): void;
 
         /* end of Stacks helpers */
         
@@ -288,7 +285,7 @@ declare global {
         /**
          * The Stacks Stimulus application singleton
          */
-        application: Stimulus.Application
+        const application: Stimulus.Application
         
         /* end of Stacks properties */
     }

--- a/lib/stacks.d.ts
+++ b/lib/stacks.d.ts
@@ -165,6 +165,11 @@ declare global {
             /** The position to place the tooltip */
             placement: AllPlacements;
         }
+        
+        interface ControllerDefinition {
+            [name: string]: any;
+            targets?: string[];
+        }
 
         /* end of interfaces */
 
@@ -256,8 +261,36 @@ declare global {
             text: string,
             options?: TooltipOptions
         ): void;
+        
+        /**
+         * Create a Stimulus controller from an old-fashioned (pre-ES6) Javascript object. All own enumerable 
+         * properties of that object will be made available on the controller prototype, with the exception of
+         * the targets property, which will be available on the controller constructor itself, i.e. statically.
+         * @param controllerDefinition plain JavaScript object that is analogous to the ES6 class
+         */
+        function createController(
+            controllerDefinition: ControllerDefinition
+        ): typeof StacksController;
+        /**
+         * Register a Stimulus controller from an old-fashioned (pre-ES6) Javascript object.
+         * @param name identifier for this controller
+         * @param controllerDefinition plain JavaScript object that is analogous to the ES6 class
+         */
+        function addController(
+            name: string,
+            controller: ControllerDefinition
+        ): void;
 
         /* end of Stacks helpers */
+        
+        /* Stacks properties */
+        
+        /**
+         * The Stacks Stimulus application singleton
+         */
+        application: Stimulus.Application
+        
+        /* end of Stacks properties */
     }
 }
 


### PR DESCRIPTION
Add the [Stimulus `application` singleton](https://github.com/StackExchange/Stacks/blob/f4addd707cc6958aa38589e722e7b804365dcedd/lib/ts/stacks.ts#L28) and [controller utilities](https://github.com/StackExchange/Stacks/blob/f4addd707cc6958aa38589e722e7b804365dcedd/lib/ts/stacks.ts#L56-L82) to the Stacks global.

The controller option is also documented in the [Stacks documentation on Javascript](https://stackoverflow.design/product/guidelines/javascript/#creating-your-own-stimulus-controllers).